### PR TITLE
sendAuthRequest接口修改调用[WXApi sendAuthReq...

### DIFF
--- a/ios/RCTWeChat.m
+++ b/ios/RCTWeChat.m
@@ -109,7 +109,9 @@ RCT_EXPORT_METHOD(sendAuthRequest:(NSString *)scope
     SendAuthReq* req = [[SendAuthReq alloc] init];
     req.scope = scope;
     req.state = state;
-    BOOL success = [WXApi sendReq:req];
+    // BOOL success = [WXApi sendReq:req];
+    UIViewController *rootViewController = [UIApplication sharedApplication].keyWindow.rootViewController;
+    BOOL success = [WXApi sendAuthReq:req viewController:rootViewController delegate:self];
     callback(@[success ? [NSNull null] : INVOKE_FAILED]);
 }
 


### PR DESCRIPTION
[WXApi sendAuthReq接口支持如下情况，当未安装微信时，会弹出使用手机号码登录微信的页面。主要是旧接口苹果无法过审，所以替换未该接口。